### PR TITLE
Root object has different merge semantics from any other object

### DIFF
--- a/src/tesseract.js
+++ b/src/tesseract.js
@@ -224,9 +224,9 @@ function Store(uuid) {
   this.conflicts = { [root_id]: {} }
   this.peer_actions = { [this._id]: [] }
   this.obj_actions = { [root_id]: {} }
-  this.root = new Map(this, root_id, {})
-  this.objects = { [this.root._id]: this.root }
-  this.links = { [this.root._id]: {} }
+  this.root = new Map(this, UUID.generate(), {})
+  this.objects = { [root_id]: new Map(this, root_id, {}) }
+  this.links = { [root_id]: {} }
   this.clock = { [this._id]: 0 }
   this.peers = {}
   this.syncing = true
@@ -279,6 +279,11 @@ function Store(uuid) {
   }
 
   this.apply = (action) => {
+    if (action.action != "create" && action.target == this.root._id && this.objects[this.root._id] === undefined) {
+      this.apply({ action: "create", target: this.root._id, value: {} })
+      this.apply({ action: "link", target: root_id, key: "root", value: action.target })
+    }
+
     let a = Object.assign({ by: this._id, clock: this.tick() }, action)
     this.push_action(a)
     this.try_apply()

--- a/test/test.js
+++ b/test/test.js
@@ -55,7 +55,6 @@ console.log("Test - 01 - map: local set / nest / link")
 console.assert(deep_equals(store1.root,mark1))
 
 let store2 = new Store("store2")
-store2.root["xxx"] = "yyy"
 store2.sync(store1)
 store2.root.obj3 = store2.root.obj
 delete store2.root.obj
@@ -66,8 +65,7 @@ let mark2 = {
   foo: 'foo',
   bar: 'foobar',
   obj2: { hello: 'world' },
-  obj3: { hello: 'world' },
-  xxx: 'yyy'
+  obj3: { hello: 'world' }
 }
 
 console.log("Test - 02 - sync both ways")
@@ -255,6 +253,8 @@ console.assert(store5.root.new_test === "444")
 
 console.log("Test - 12 - messy network")
 
+store4 = new Store("store4")
+store5 = new Store("store5")
 store4.link(store3)
 store5.link(store2)
 store5.link(store1)


### PR DESCRIPTION
You explained in our call that the root object always has a fixed all-zeros UUID so that you can independently create two stores, put some data in each, and merge them after the fact:

```js
let store1 = new Store('store1')
let store2 = new Store('store2')
store1.root.x = 42
store2.root.y = 'ok'
store1.link(store2)
store1.root
// { y: 'ok', x: 42 }
```

However, that merging behaviour only exists on the root object. For any nested object, independently creating objects in the same location results in one object being arbitrarily chosen as the winner, with the other being relegated to the conflicts:

```js
let store1 = new Store('store1')
let store2 = new Store('store2')
store1.root.obj = {}
store2.root.obj = {}
store1.root.obj.x = 42
store2.root.obj.y = 'ok'
store1.link(store2)
store1.root
// { obj: { y: 'ok' } }
```

I can see good reasons for either semantics, but I find it surprising that the root object should behave differently from other objects. To fix the inconsistency, I suggest that it would be better to give the root object the same choose-one-or-the-other semantics as other objects, by generating a random root UUID at each store, rather than using a fixed all-zeros UUID.

This pull request lazily creates a root object with random UUID the first time you write to a store, and sets a link to that object (the link has a target of all-zeros UUID, and a key of `"root"`). The lazy approach means that if you link an empty store to an existing store, the empty store simply adopts the root object of the existing store (so the API is unchanged). If you link two stores that have different root objects, the usual link-conflict resolution is used to choose between one of the two roots.