### PR TITLE
Spooky action at a distance

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -86,6 +86,10 @@ console.assert(deep_equals(store1.root,store2.root))
 console.assert(store2.root.linktest1 == "123")
 console.assert(store1.root.linktest2 == "abc")
 
+store1.root.a = {b: {c: "d"}}
+store2.root.a.b.c = "ddd"
+console.assert(store1.root.a.b.c == "ddd")
+
 console.log("Test - 04 - linked w two nodes who cant talk")
 store3.link(store2)
 store3.root.linktest3 = "zzz"
@@ -109,6 +113,11 @@ console.assert(store3.root.linktest1 == "aaa")
 console.assert(store2.root.linktest1 == "aaa")
 console.assert(store1.root.linktest1 == "bbb")
 
+store3.root.a.b.c = "xyz"
+console.assert(store3.root.a.b.c == "xyz")
+console.assert(store2.root.a.b.c == "ddd")
+console.assert(store1.root.a.b.c == "ddd")
+
 console.log("Test - 06 - unpause syncing")
 
 store2.unpause()
@@ -118,6 +127,9 @@ console.assert(store1.root.linktest3 == "vvv")
 console.assert(store3.root.linktest1 == "bbb")
 console.assert(store2.root.linktest1 == "bbb")
 console.assert(store1.root.linktest1 == "bbb")
+console.assert(store3.root.a.b.c == "xyz")
+console.assert(store2.root.a.b.c == "xyz")
+console.assert(store1.root.a.b.c == "xyz")
 
 console.log("Test - 07 - map: conflicts")
 
@@ -314,10 +326,10 @@ console.assert(deep_equals(store6.root.lists,[12,12,11]))
 
 console.log("Test - 19 - list: deletes")
 
-store6.root.lists[0] = undefined
+store6.root.lists[0] = null
 delete store6.root.lists[1]
 
-let skipList = [undefined]
+let skipList = [null]
 skipList[2] = 11
 
 console.assert(deep_equals(store6.root.lists,skipList))


### PR DESCRIPTION
Say you assign an object with nested objects to a property, for example: `store1.root.a = {b: {c: "d"}}`. In the current implementation, this creates a new CRDT map object for the object containing `b`, but any nested objects are simply passed along as pointers, and not cloned. Since these objects all live in the same address space, when you change a nested object on one store (`store1.root.a.b.c = "ddd"`), that change immediately appears on any linked stores, even if synchronisation is currently paused. It's like "spooky action at a distance": state changes on another simulated node, without any explicit action being passed over the simulated network.

The solution, of course, is to deep-clone any objects as they are passed from one store to another, to avoid inadvertently sharing pointers to mutable objects between stores. However, simply adding that deep-cloning breaks the current sync implementation.

This pull request fixes the issue by recursively creating CRDT maps for any nested objects, and linking to them, in addition to deep-cloning.