### PR TITLE
Use strict mode for running tests

### DIFF
--- a/src/tesseract.js
+++ b/src/tesseract.js
@@ -110,6 +110,7 @@ let ListHandler = {
     if (key.startsWith("_")) { throw "Invalid Key" }
     // TODO - do i need to distinguish 'del' from 'unlink' - right now, no, but keep eyes open for trouble
     target._store.apply({ action: "del", target: target._id, key: key })
+    return true
   }
 }
 
@@ -129,6 +130,7 @@ let MapHandler = {
     if (key.startsWith("_")) { throw "Invalid Key" }
     // TODO - do i need to distinguish 'del' from 'unlink' - right now, no, but keep eyes open for trouble
     target._store.apply({ action: "del", target: target._id, key: key })
+    return true
   }
 }
 

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--use_strict


### PR DESCRIPTION
Added option for Mocha test runner, and added the missing `true` return values for `deleteProperty` handlers.