### PR TITLE
topologically sort changes before applying

### DIFF
--- a/backend/new.js
+++ b/backend/new.js
@@ -1709,13 +1709,11 @@ function topologicalSort(xs, outgoingEdges) {
     if (!unmarked.has(n)) return
     unmarked.delete(n)
 
-    if (tempMarks.has(n))
-      throw new Error("Not a DAG")
+    if (tempMarks.has(n)) throw new Error("Not a DAG")
 
     tempMarks.add(n)
     stack.push([append, n])
-    for (const m of outgoingEdges(n))
-      stack.push([visit, m])
+    for (const m of outgoingEdges(n)) stack.push([visit, m])
   }
   function append(n) {
     tempMarks.delete(n)


### PR DESCRIPTION
This topologically sorts changes before application.

In the worst case, if the change list was sorted in reverse topological order,
applyChanges would traverse the change list O(N^2) times. By first sorting the
incoming changes topologically, we reduce that to O(N + E), where E is the
number of dependency edges.
